### PR TITLE
Fix: unknown prop 'redraw' warning in React v15.2

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -11,6 +11,7 @@ var Chart = require('chart.js');
 
 module.exports = {
   createClass: function(chartType, methodNames, dataKey) {
+    var excludedProps = ['data', 'options', 'redraw'];
     var classData = {
       displayName: chartType + 'Chart',
       getInitialState: function() { return {}; },
@@ -20,7 +21,7 @@ module.exports = {
         };
         for (var name in this.props) {
           if (this.props.hasOwnProperty(name)) {
-            if (name !== 'data' && name !== 'options') {
+            if (excludedProps.indexOf(name) === -1) {
               _props[name] = this.props[name];
             }
           }


### PR DESCRIPTION
React v15.2 warns when a DOM element is rendered with an invalid property (see https://fb.me/react-unknown-prop)
